### PR TITLE
Add ADOT Operator to the test framework

### DIFF
--- a/terraform/eks/adot-operator/adot-operator-values.yaml
+++ b/terraform/eks/adot-operator/adot-operator-values.yaml
@@ -1,7 +1,7 @@
 manager:
   image:
     repository: public.ecr.aws/aws-observability/adot-operator
-    tag: "v0.29.0"
+    tag: "latest"
 
 kubeRBACProxy:
   image:

--- a/terraform/eks/adot-operator/adot-operator-values.yaml
+++ b/terraform/eks/adot-operator/adot-operator-values.yaml
@@ -6,4 +6,4 @@ manager:
 kubeRBACProxy:
   image:
     repository: public.ecr.aws/aws-observability/mirror-kube-rbac-proxy
-    tag: "v0.5.0"
+    tag: "v0.8.0"

--- a/terraform/eks/adot-operator/adot-operator-values.yaml
+++ b/terraform/eks/adot-operator/adot-operator-values.yaml
@@ -1,0 +1,9 @@
+manager:
+  image:
+    repository: public.ecr.aws/aws-observability/adot-operator
+    tag: "v0.29.0"
+
+kubeRBACProxy:
+  image:
+    repository: public.ecr.aws/aws-observability/mirror-kube-rbac-proxy
+    tag: "v0.5.0"

--- a/terraform/eks/adot-operator/adot_collector_deployment.tpl
+++ b/terraform/eks/adot-operator/adot_collector_deployment.tpl
@@ -5,7 +5,7 @@ metadata:
   namespace: ${AOC_NAMESPACE}
 spec:
   image: public.ecr.aws/aws-observability/aws-otel-collector:latest
-  mode: deployment
+  mode: ${AOC_DEPLOY_MODE}
   serviceAccount: ${AOC_SERVICEACCOUNT}
   config: |
     ${AOC_CONFIG}

--- a/terraform/eks/adot-operator/adot_collector_deployment.tpl
+++ b/terraform/eks/adot-operator/adot_collector_deployment.tpl
@@ -1,0 +1,11 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: aoc
+  namespace: ${AOC_NAMESPACE}
+spec:
+  image: public.ecr.aws/aws-observability/aws-otel-collector:latest
+  mode: deployment
+  serviceAccount: ${AOC_SERVICEACCOUNT}
+  config: |
+    ${AOC_CONFIG}

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -24,12 +24,12 @@ resource "helm_release" "adot-operator-cert-manager" {
 
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version = "v1.4.0"
+  version    = "v1.4.0"
 
   create_namespace = true
 
   set {
-    name = "installCRDs"
+    name  = "installCRDs"
     value = "true"
   }
 
@@ -42,7 +42,7 @@ resource "helm_release" "adot-operator-cert-manager" {
 }
 
 resource "helm_release" "adot-operator" {
-  name      = "adot-operator-${var.testing_id}"
+  name = "adot-operator-${var.testing_id}"
 
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -1,0 +1,59 @@
+# ------------------------------------------------------------------------
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+variable "testing_id" {
+  type    = string
+  default = ""
+}
+
+resource "helm_release" "adot-operator-cert-manager" {
+  name      = "cert-manager"
+  namespace = "cert-manager"
+
+  repository = "https://charts.jetstack.io"
+  chart      = "cert-manager"
+  version = "v1.4.0"
+
+  create_namespace = true
+
+  set {
+    name = "installCRDs"
+    value = "true"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      kubectl wait --timeout=5m --for=condition=available deployment cert-manager -n cert-manager
+      kubectl wait --timeout=5m --for=condition=available deployment cert-manager-webhook -n cert-manager
+    EOT
+  }
+}
+
+resource "helm_release" "adot-operator" {
+  name      = "adot-operator-${var.testing_id}"
+
+  repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
+  chart      = "opentelemetry-operator"
+
+  values = [
+    file("./adot-operator/adot-operator-values.yaml")
+  ]
+
+  provisioner "local-exec" {
+    command = "kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system"
+  }
+
+  depends_on = [helm_release.adot-operator-cert-manager]
+}

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -134,7 +134,7 @@ resource "kubernetes_service_account" "aoc-agent-role" {
 }
 
 module "demo_adot_operator" {
-  count = replace(var.testcase, "_adot_operator", "") == var.testcase ? 0 : 1
+  count  = replace(var.testcase, "_adot_operator", "") == var.testcase ? 0 : 1
   source = "./adot-operator"
 
   testing_id = module.common.testing_id
@@ -184,6 +184,6 @@ module "validator" {
   aws_secret_access_key = var.aws_secret_access_key
 
   depends_on = [
-  module.aoc_oltp,
+    module.aoc_oltp,
   module.demo_adot_operator]
 }

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -133,6 +133,13 @@ resource "kubernetes_service_account" "aoc-agent-role" {
   automount_service_account_token = true
 }
 
+module "demo_adot_operator" {
+  count = replace(var.testcase, "_adot_operator", "") == var.testcase ? 0 : 1
+  source = "./adot-operator"
+
+  testing_id = module.common.testing_id
+}
+
 
 ##########################################
 # Validation
@@ -177,5 +184,6 @@ module "validator" {
   aws_secret_access_key = var.aws_secret_access_key
 
   depends_on = [
-  module.aoc_oltp]
+  module.aoc_oltp,
+  module.demo_adot_operator]
 }

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -133,7 +133,7 @@ resource "kubernetes_service_account" "aoc-agent-role" {
   automount_service_account_token = true
 }
 
-module "demo_adot_operator" {
+module "adot_operator" {
   count  = replace(var.testcase, "_adot_operator", "") == var.testcase ? 0 : 1
   source = "./adot-operator"
 
@@ -185,5 +185,5 @@ module "validator" {
 
   depends_on = [
     module.aoc_oltp,
-  module.demo_adot_operator]
+  module.adot_operator]
 }

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -201,16 +201,13 @@ data "template_file" "adot_collector_config_file" {
   template = file("./adot-operator/adot_collector_deployment.tpl")
 
   vars = {
-    AOC_NAMESPACE            = kubernetes_namespace.aoc_ns.metadata[0].name
-    AOC_DEPLOY_MODE          = var.aoc_deploy_mode
-    AOC_SERVICEACCOUNT       = "aoc-role-${module.common.testing_id}"
-    AOC_CONFIG               = module.basic_components.0.otconfig_content
-    AOC_LABEL_SELECTOR       = local.aoc_label_selector
-    MOCKED_SERVER_CONFIG_MAP = kubernetes_config_map.mocked_server_cert.0.metadata[0].name
-    MOCKED_SERVER_IMAGE      = local.mocked_server_image
+    AOC_NAMESPACE      = kubernetes_namespace.aoc_ns.metadata[0].name
+    AOC_DEPLOY_MODE    = var.aoc_deploy_mode
+    AOC_SERVICEACCOUNT = "aoc-role-${module.common.testing_id}"
+    AOC_CONFIG         = module.basic_components.0.otconfig_content
   }
 
-  depends_on = [module.demo_adot_operator]
+  depends_on = [module.adot_operator]
 }
 
 resource "local_file" "adot_collector_deployment" {
@@ -219,7 +216,7 @@ resource "local_file" "adot_collector_deployment" {
   filename = "adot_collector.yaml"
   content  = data.template_file.adot_collector_config_file.0.rendered
 
-  depends_on = [module.demo_adot_operator]
+  depends_on = [module.adot_operator]
 }
 
 resource "null_resource" "aoc_deployment_adot_operator" {
@@ -229,7 +226,7 @@ resource "null_resource" "aoc_deployment_adot_operator" {
     command = "kubectl apply -f ${local_file.adot_collector_deployment.0.filename}"
   }
 
-  depends_on = [module.demo_adot_operator]
+  depends_on = [module.adot_operator]
 }
 
 resource "kubernetes_service" "sample_app_service" {

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -202,6 +202,7 @@ data "template_file" "adot_collector_config_file" {
 
   vars = {
     AOC_NAMESPACE            = kubernetes_namespace.aoc_ns.metadata[0].name
+    AOC_DEPLOY_MODE          = var.aoc_deploy_mode
     AOC_SERVICEACCOUNT       = "aoc-role-${module.common.testing_id}"
     AOC_CONFIG               = module.basic_components.0.otconfig_content
     AOC_LABEL_SELECTOR       = local.aoc_label_selector

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -201,12 +201,12 @@ data "template_file" "adot_collector_config_file" {
   template = file("./adot-operator/adot_collector_deployment.tpl")
 
   vars = {
-    AOC_NAMESPACE = kubernetes_namespace.aoc_ns.metadata[0].name
-    AOC_SERVICEACCOUNT = "aoc-role-${module.common.testing_id}"
-    AOC_CONFIG = module.basic_components.0.otconfig_content
-    AOC_LABEL_SELECTOR = local.aoc_label_selector
+    AOC_NAMESPACE            = kubernetes_namespace.aoc_ns.metadata[0].name
+    AOC_SERVICEACCOUNT       = "aoc-role-${module.common.testing_id}"
+    AOC_CONFIG               = module.basic_components.0.otconfig_content
+    AOC_LABEL_SELECTOR       = local.aoc_label_selector
     MOCKED_SERVER_CONFIG_MAP = kubernetes_config_map.mocked_server_cert.0.metadata[0].name
-    MOCKED_SERVER_IMAGE = local.mocked_server_image
+    MOCKED_SERVER_IMAGE      = local.mocked_server_image
   }
 
   depends_on = [module.demo_adot_operator]
@@ -216,7 +216,7 @@ resource "local_file" "adot_collector_deployment" {
   count = var.aoc_base_scenario == "oltp" && replace(var.testcase, "_adot_operator", "") != var.testcase ? 1 : 0
 
   filename = "adot_collector.yaml"
-  content = data.template_file.adot_collector_config_file.0.rendered
+  content  = data.template_file.adot_collector_config_file.0.rendered
 
   depends_on = [module.demo_adot_operator]
 }

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -35,3 +35,9 @@ variable "sample_app_image_repo" {
 variable "aoc_base_scenario" {
   default = "oltp"
 }
+
+// aoc_deploy_mode refers to the mode to deploy the Collector CR. This is only used when we test the Operator.
+// options: deployment, daemonset, statefulset, sidecar
+variable "aoc_deploy_mode" {
+  default = "deployment"
+}

--- a/terraform/testcases/otlp_trace_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_adot_operator/otconfig.tpl
@@ -1,0 +1,26 @@
+extensions:
+      pprof:
+        endpoint: 0.0.0.0:1777
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:${grpc_port}
+
+    processors:
+      batch:
+
+    exporters:
+      logging:
+        loglevel: debug
+      awsxray:
+        local_mode: true
+        region: '${region}'
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [awsxray]
+      extensions: [pprof]

--- a/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
@@ -1,0 +1,4 @@
+validation_config = "spark-otel-trace-validation.yml"
+
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "trace"

--- a/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
@@ -1,0 +1,28 @@
+receivers:
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: 'kubernetes-service-endpoints'
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - source_labels: [ __meta_kubernetes_namespace ]
+              action: keep
+              regex: "aoc-ns-${testing_id}"
+            - source_labels: [ __meta_kubernetes_pod_label_app ]
+              action: keep
+              regex: "sample-app"
+    exporters:
+      awsprometheusremotewrite:
+        endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+        aws_auth:
+          region: ${region}
+          service: "aps"
+        timeout: 10s
+      logging:
+        loglevel: debug
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [awsprometheusremotewrite, logging]

--- a/terraform/testcases/prometheus_sd_adot_operator/parameters.tfvars
+++ b/terraform/testcases/prometheus_sd_adot_operator/parameters.tfvars
@@ -1,0 +1,6 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "prometheus-sd-validation.yml"
+
+sample_app = "prometheus"
+
+sample_app_mode = "pull"

--- a/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
@@ -1,0 +1,21 @@
+receivers:
+      prometheus:
+        config:
+          global:
+            scrape_interval: 15s
+          scrape_configs:
+          - job_name: "test-prometheus-sample-app"
+            static_configs:
+            - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
+    exporters:
+      awsprometheusremotewrite:
+        endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+        aws_auth:
+          region: ${region}
+          service: "aps"
+        timeout: 15s
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [awsprometheusremotewrite]

--- a/terraform/testcases/prometheus_static_adot_operator/parameters.tfvars
+++ b/terraform/testcases/prometheus_static_adot_operator/parameters.tfvars
@@ -1,0 +1,12 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "prometheus-metric-validation.yml"
+
+sample_app = "prometheus"
+
+soaking_sample_app = "prometheus"
+
+soaking_data_type = "prometheus"
+
+sample_app_mode = "pull"
+
+ecs_taskdef_directory = "prometheus"


### PR DESCRIPTION
This PR adds ADOT Operator to the current ADOT test framework along with two test cases: `prometheus_sd_adot_operator` and `prometheus_static_adot_operator`.

When we run either of the above test cases, Terraform will:
- Install ADOT Operator through Helm
- Configure the ADOT Collector through `OpenTelemetryCollector` CRD
- Run the validator to validate if the metrics data arrives the desired backends

cc @alolita @mxiamxia